### PR TITLE
[WIP] Fix `light_verifier_accounts` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anchor-syn = "0.26"
 bs58 = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
+
+[dev-dependencies]
+anchor-lang = "0.26"
+anchor-spl = "0.26"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use anchor_syn::AccountsStruct;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, ItemStruct};
 
@@ -12,11 +13,15 @@ pub fn pubkey(input: TokenStream) -> TokenStream {
         .into()
 }
 
+// #[proc_macro_derive(LightAccounts, attributes(account, instruction))]
 #[proc_macro_attribute]
 pub fn light_verifier_accounts(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as expand::LightVerifierAccountsArgs);
-    let item = parse_macro_input!(item as ItemStruct);
-    expand::light_verifier_accounts(args, item)
+    let item_strct = item.clone();
+    let strct = parse_macro_input!(item_strct as ItemStruct);
+    let accounts_strct = parse_macro_input!(item as AccountsStruct);
+
+    expand::light_verifier_accounts(args, strct, accounts_strct)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }


### PR DESCRIPTION
Before this change, using this macro in real crates was resulting in `not a non-macro attribute errors`. That's because `#[derive(Accounts)]` macro in anchor is a proc-derive macro, which uses `accounts` as an attribute.

However, we can't implement our `light_verifier_accounts` macro as a proc-derive macro, because we are not able to append fields to the original struct definition through it. To be able to properly modify the body of the struct.